### PR TITLE
feat: add auto-connect, getOrSet, exists, ttl and command-driven reconnect

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,8 @@ Resilient Redis/Valkey cache client with graceful degradation, fast failure dete
 - **Fail-fast**: Quick failure timeout (don't wait for slow connections)
 - **Circuit breaker**: Automatic cooldown after failure, prevents cascade failures
 - **Graceful degradation**: Return default values when unavailable
+- **Auto-connect**: No manual `connect()` required, lazy connection on first command
+- **Cache-aside pattern**: Built-in `getOrSet()` for common fetch-or-compute pattern
 - **Configurable error handling**: Graceful (default) or throw exceptions
 - **Await-friendly API**: Modern async/await interface
 - **Replaceable**: Provider pattern for swapping implementations
@@ -32,15 +34,15 @@ npm install resilient-cache
 ```typescript
 import { ResilientCacheClient, CacheKeyBuilder, CacheProvider } from 'resilient-cache';
 
-// Initialize at app startup
+// Initialize at app startup - no connect() needed, auto-connects on first command
 const client = new ResilientCacheClient({
   host: process.env.REDIS_HOST!,
   port: 6379,
   password: process.env.REDIS_PASSWORD,
   // onError: 'graceful' is the default
+  // autoConnect: true is the default
 });
 
-await client.connect();
 CacheProvider.initialize(client);
 
 // Key builder for consistent key naming
@@ -55,6 +57,21 @@ if (!cached) {
   const fresh = await loadFromDatabase();
   await client.set(orgKeys.key('prompts'), fresh, 7200); // Returns false if unavailable
 }
+```
+
+### Cache-Aside Pattern with getOrSet()
+
+```typescript
+// Simplify fetch-or-compute pattern with getOrSet()
+const userData = await client.getOrSet(
+  keys.forUser(userId).key('profile'),
+  async () => {
+    // Called only on cache miss
+    return await fetchUserFromDatabase(userId);
+  },
+  3600 // TTL in seconds
+);
+// Returns cached value if available, otherwise calls factory and caches result
 ```
 
 ### Throw Mode for Specific Calls
@@ -110,24 +127,82 @@ export async function cacheHealthCheck() {
 }
 ```
 
+### Checking Key Existence and TTL
+
+```typescript
+// Check if a key exists before expensive operations
+if (await client.exists(lockKey)) {
+  throw new Error('Operation already in progress');
+}
+
+// Check remaining TTL for cache warming decisions
+const remaining = await client.ttl(cacheKey);
+if (remaining > 0 && remaining < 60) {
+  // Cache expires soon - trigger background refresh
+  refreshInBackground(cacheKey);
+}
+// Note: ttl() returns -1 if key has no TTL, -2 if key doesn't exist
+```
+
+### Monitoring Connection Status
+
+```typescript
+// Get detailed connection status for dashboards/monitoring
+const status = client.getStatus();
+
+console.log({
+  state: status.state,              // 'connected', 'cooldown', 'failed', etc.
+  lastSuccessAt: status.lastSuccessAt,  // Last successful operation
+  lastError: status.lastError?.message,
+  reconnectAttempts: status.reconnectAttempts,
+  cooldownEndsAt: status.cooldownEndsAt,  // When cooldown expires (if in cooldown)
+});
+
+// Register for state change notifications
+client.onStateChange((status) => {
+  if (status.state === 'cooldown') {
+    logger.warn('Cache entered cooldown', { error: status.lastError });
+  } else if (status.state === 'connected') {
+    logger.info('Cache reconnected');
+  }
+});
+```
+
 ### Testing with MockCacheClient
 
 ```typescript
 import { MockCacheClient, CacheProvider } from 'resilient-cache';
 
 describe('MyService', () => {
+  let mockClient: MockCacheClient;
+
   beforeEach(() => {
+    mockClient = new MockCacheClient();
     CacheProvider.reset();
-    CacheProvider.initialize(new MockCacheClient());
+    CacheProvider.initialize(mockClient);
   });
 
   it('should handle cache failure gracefully', async () => {
-    const mockClient = CacheProvider.getClient() as MockCacheClient;
     mockClient.setSimulateFailure(true);
 
     // Your service should still work
     const result = await myService.getData();
     expect(result).toBeDefined();
+  });
+
+  it('should use cached value when available', async () => {
+    await mockClient.set('user:123', { name: 'John' });
+
+    const result = await myService.getUser('123');
+    expect(result.name).toBe('John');
+  });
+
+  it('should verify cache was populated', async () => {
+    await myService.getUser('123'); // Should cache the result
+
+    // Access internal store for assertions
+    const store = mockClient.getStore();
+    expect(store.has('user:123')).toBe(true);
   });
 });
 ```
@@ -149,6 +224,7 @@ const client = new ResilientCacheClient({
   maxReconnectAttempts?: number; // Max reconnect attempts (default: Infinity)
   enableOfflineQueue?: boolean;  // Queue commands when disconnected (default: false)
   onError?: 'graceful' | 'throw'; // Error handling mode (default: 'graceful')
+  autoConnect?: boolean;     // Auto-connect on first command (default: true)
 });
 ```
 
@@ -169,6 +245,9 @@ const client = new ResilientCacheClient({
 | `increment(key, amount?, defaultValue?, options?)` | `defaultValue` | throws `CacheUnavailableError` |
 | `decrement(key, amount?, defaultValue?, options?)` | `defaultValue` | throws `CacheUnavailableError` |
 | `decrementOrInit(key, defaultValue, ttlSeconds, options?)` | `defaultValue` | throws `CacheUnavailableError` |
+| `getOrSet<T>(key, factory, ttlSeconds?, options?)` | factory result | throws `CacheUnavailableError` |
+| `exists(key, options?)` | `false` | throws `CacheUnavailableError` |
+| `ttl(key, options?)` | `-2` | throws `CacheUnavailableError` |
 
 ### CacheKeyBuilder
 
@@ -208,13 +287,65 @@ error.timeoutMs;  // Timeout duration
 
 ---
 
+## Design Principles
+
+This library is built around the principle that **cache is non-critical infrastructure**. Your application should continue working even when Redis/Valkey is completely unavailable.
+
+### Key Design Decisions
+
+| Principle | Behavior |
+|-----------|----------|
+| **Always available** | All commands work even when Redis is down - they return graceful defaults |
+| **No manual connect** | Auto-connects on first command, auto-reconnects after failures |
+| **Fail fast** | Commands never block waiting for connection - return defaults immediately |
+| **Command-driven reconnect** | Reconnection only happens when commands need it, not via background timers |
+| **Circuit breaker** | After failure, enters cooldown to prevent retry storms |
+| **Status transparency** | `getStatus()` provides real connection state for monitoring |
+
+### Connection Behavior
+
+```
+Scenario: Redis starts down, comes up later
+
+Request 1 → triggers connect attempt → fails → enters cooldown → returns default
+Request 2 → cooldown active → returns default immediately (no retry)
+Request 3 → cooldown active → returns default immediately (no retry)
+...
+[cooldown expires after 10s]
+Request N → cooldown expired → triggers reconnect → Redis is back! → returns real value
+Request N+1 → connected → returns real value
+```
+
+```
+Scenario: Many concurrent requests during connection
+
+Request 1 → triggers connect attempt → waiting...
+Request 2 → sees "connecting" state → returns default immediately (fail fast)
+Request 3 → sees "connecting" state → returns default immediately (fail fast)
+...
+Request 1 → connection succeeds → returns real value
+Request N → now connected → returns real value
+```
+
+### When to Use Throw Mode
+
+Use `{ onError: 'throw' }` only when you need to **know** if cache failed:
+
+- Health check endpoints
+- Admin cache management UIs
+- Critical operations where cache failure should block the operation
+
+For normal application code, use graceful mode (default) - your app keeps working.
+
+---
+
 ## Connection State Machine
 
 ```
                     ┌─────────────┐
-                    │disconnected │
-                    └──────┬──────┘
-                           │ connect()
+        first       │disconnected │
+        command ───►└──────┬──────┘
+                           │ auto-connect
                            ▼
                     ┌─────────────┐
               ┌────►│ connecting  │◄────┐
@@ -229,20 +360,22 @@ error.timeoutMs;  // Timeout duration
               │    lost    │            │
               │            ▼            │
               │     ┌─────────────┐     │
-              │     │reconnecting │─────┤
+              │     │  cooldown   │─────┤ failure
               │     └──────┬──────┘     │
               │            │            │
-              │    failure │            │
+              │   cooldown │            │
+              │   expired  │            │
+              │   + command│            │
               │            ▼            │
-     cooldown │     ┌─────────────┐     │
-     expires  └─────│  cooldown   │     │
-                    └──────┬──────┘     │
-                           │            │
-               max retries │            │
-                           ▼            │
-                    ┌─────────────┐     │
-                    │   failed    │─────┘
-                    └─────────────┘  manual reconnect
+              │     ┌─────────────┐     │
+              └─────│reconnecting │─────┘
+                    └──────┬──────┘
+                           │
+               max retries │
+                           ▼
+                    ┌─────────────┐
+                    │   failed    │───► next command resets & retries
+                    └─────────────┘
 ```
 
 This is a simplified [circuit breaker pattern](https://martinfowler.com/bliki/CircuitBreaker.html):
@@ -253,7 +386,10 @@ This is a simplified [circuit breaker pattern](https://martinfowler.com/bliki/Ci
 | OPEN | `cooldown` | Reject immediately, don't attempt connection |
 | HALF-OPEN | `reconnecting` | Test if service recovered |
 
-**Key difference**: Unlike a traditional circuit breaker that trips after N failures, this library enters cooldown immediately on any connection failure. This is appropriate for cache clients where a single timeout already indicates the server is struggling.
+**Key behaviors:**
+- **No timers**: Reconnection is command-driven, not timer-driven. If no commands are issued, no reconnection attempts are made.
+- **Immediate cooldown**: Unlike traditional circuit breakers that trip after N failures, this enters cooldown on any connection failure (appropriate for cache where one timeout means trouble).
+- **Fail fast during connecting**: Concurrent requests during connection don't pile up - they get graceful defaults immediately.
 
 ---
 

--- a/src/MockCacheClient.ts
+++ b/src/MockCacheClient.ts
@@ -251,6 +251,83 @@ export class MockCacheClient implements ICacheClient {
   }
 
   /**
+   * Get a value from cache, or set it using a factory function if not found
+   */
+  async getOrSet<T>(
+    key: string,
+    factory: () => Promise<T>,
+    ttlSeconds?: number,
+    options?: CallOptions,
+  ): Promise<T> {
+    // Try to get from cache first
+    const cached = await this.get<T>(key, undefined, options);
+    if (cached !== null) {
+      return cached;
+    }
+
+    // Cache miss or unavailable - call factory
+    const value = await factory();
+
+    // Try to cache the result (best effort)
+    if (!this.simulateFailure) {
+      const storedValue: StoredValue = {
+        value,
+        expiresAt: ttlSeconds ? Date.now() + ttlSeconds * 1000 : undefined,
+      };
+      this.store.set(key, storedValue);
+    }
+
+    return value;
+  }
+
+  /**
+   * Check if a key exists in cache
+   */
+  async exists(key: string, options?: CallOptions): Promise<boolean> {
+    if (this.simulateFailure) {
+      return this.handleError('exists', false, options);
+    }
+
+    if (this.isExpired(key)) {
+      return false;
+    }
+
+    return this.store.has(key);
+  }
+
+  /**
+   * Get the remaining TTL of a key in seconds
+   * Returns -1 if key exists but has no TTL
+   * Returns -2 if key doesn't exist
+   */
+  async ttl(key: string, options?: CallOptions): Promise<number> {
+    if (this.simulateFailure) {
+      return this.handleError('ttl', -2, options);
+    }
+
+    if (this.isExpired(key)) {
+      return -2;
+    }
+
+    const item = this.store.get(key);
+    if (!item) {
+      return -2;
+    }
+
+    if (!item.expiresAt) {
+      return -1;
+    }
+
+    const remainingMs = item.expiresAt - Date.now();
+    if (remainingMs <= 0) {
+      this.store.delete(key);
+      return -2;
+    }
+
+    return Math.ceil(remainingMs / 1000);
+  }
+
+  /**
    * Connect to cache (no-op for mock)
    */
   async connect(): Promise<void> {

--- a/src/types.ts
+++ b/src/types.ts
@@ -32,6 +32,13 @@ export interface CacheClientOptions {
    * - 'throw': Throw CacheUnavailableError when cache unavailable
    */
   onError?: 'graceful' | 'throw';
+
+  /**
+   * Auto-connect on first command (default: true)
+   * When true, connect() is called automatically when the first command is issued.
+   * When false, you must call connect() explicitly before issuing commands.
+   */
+  autoConnect?: boolean;
 }
 
 /**
@@ -74,6 +81,9 @@ export interface ConnectionStatus {
 
   /** When the cooldown period ends (if in cooldown state) */
   cooldownEndsAt?: Date;
+
+  /** Timestamp of last successful command execution */
+  lastSuccessAt?: Date;
 }
 
 /**
@@ -191,6 +201,37 @@ export interface ICacheClient {
     ttlSeconds: number,
     options?: CallOptions,
   ): Promise<number>;
+
+  /**
+   * Get a value from cache, or set it using a factory function if not found
+   * @param key - Cache key
+   * @param factory - Async function to generate the value if cache miss
+   * @param ttlSeconds - Time to live in seconds (optional)
+   * @param options - Per-call options
+   * @returns The cached or newly generated value
+   */
+  getOrSet<T>(
+    key: string,
+    factory: () => Promise<T>,
+    ttlSeconds?: number,
+    options?: CallOptions,
+  ): Promise<T>;
+
+  /**
+   * Check if a key exists in cache
+   * @param key - Cache key
+   * @param options - Per-call options
+   * @returns true if key exists, false otherwise (or if unavailable in graceful mode)
+   */
+  exists(key: string, options?: CallOptions): Promise<boolean>;
+
+  /**
+   * Get the remaining TTL of a key in seconds
+   * @param key - Cache key
+   * @param options - Per-call options
+   * @returns TTL in seconds, -1 if no TTL set, -2 if key doesn't exist (or if unavailable in graceful mode)
+   */
+  ttl(key: string, options?: CallOptions): Promise<number>;
 }
 
 /**


### PR DESCRIPTION
## Summary

Adds resilience enhancements to make the cache client truly "set and forget":

- **Auto-connect** (`autoConnect: true` default) - No manual `connect()` needed, lazy connection on first command
- **`getOrSet()`** - Cache-aside pattern helper with async factory
- **`exists()` / `ttl()`** - Key existence and TTL inspection methods
- **`lastSuccessAt`** - Track last successful operation timestamp
- **Command-driven reconnect** - No background timers, reconnection only happens when commands need it
- **Fail fast during connecting** - Concurrent requests get graceful defaults immediately (no pileup)

## Design Principles

| Principle | Behavior |
|-----------|----------|
| Always available | All commands work even when Redis is down |
| No manual connect | Auto-connects on first command, auto-reconnects after failures |
| Fail fast | Commands never block waiting for connection |
| Command-driven reconnect | No timers - reconnection only when needed |
| Circuit breaker | Cooldown after failure prevents retry storms |

## Changes

- `src/types.ts` - Added `autoConnect` option, `lastSuccessAt` field, new interface methods
- `src/ResilientCacheClient.ts` - Implemented all features, command-driven reconnect
- `src/MockCacheClient.ts` - Added corresponding mock implementations
- `tests/*.test.ts` - Added unit tests (133 total)
- `tests/integration/*.test.ts` - Added integration tests (36 total)
- `README.md` - Added design principles section, examples, updated API reference

## Test plan

- [x] Unit tests pass (133 tests)
- [x] Integration tests pass (36 tests)
- [x] Lint passes
- [x] Build succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)