### PR TITLE
feat: add batch operations and distributed lock support

### DIFF
--- a/README.md
+++ b/README.md
@@ -304,7 +304,7 @@ const client = new ResilientCacheClient({
 | `exists(key, options?)` | `false` | throws `CacheUnavailableError` |
 | `ttl(key, options?)` | `-2` | throws `CacheUnavailableError` |
 | `setIfNotExists<T>(key, value, ttlSeconds?, options?)` | `false` | throws `CacheUnavailableError` |
-| `getMany<T>(keys, options?)` | `(null)[]` | throws `CacheUnavailableError` |
+| `getMany<T>(keys, options?)` | `null[]` (same length as input) | throws `CacheUnavailableError` |
 | `setMany<T>(entries, ttlSeconds?, options?)` | `false` | throws `CacheUnavailableError` |
 | `expire(key, ttlSeconds, options?)` | `false` | throws `CacheUnavailableError` |
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "resilient-cache",
-  "version": "0.1.1",
+  "version": "0.3.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "resilient-cache",
-      "version": "0.1.1",
+      "version": "0.3.0",
       "license": "Apache-2.0",
       "dependencies": {
         "ioredis": "^5.4.1"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "resilient-cache",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "description": "Resilient Redis/Valkey cache client with graceful degradation, fast failure detection, and delayed reconnection",
   "type": "module",
   "main": "dist/index.js",

--- a/src/MockCacheClient.ts
+++ b/src/MockCacheClient.ts
@@ -442,10 +442,8 @@ export class MockCacheClient implements ICacheClient {
       return false;
     }
 
-    const item = this.store.get(key);
-    if (!item) {
-      return false;
-    }
+    // After isExpired check, we know the key exists and is not expired
+    const item = this.store.get(key)!;
 
     // Update the expiry time
     this.store.set(key, {

--- a/src/ResilientCacheClient.ts
+++ b/src/ResilientCacheClient.ts
@@ -558,10 +558,10 @@ export class ResilientCacheClient implements ICacheClient {
     }
     return this.executeCommand('setMany', false, options, async () => {
       // Build key-value pairs for MSET
-      const args: string[] = [];
-      for (const entry of entries) {
-        args.push(entry.key, this.serialize(entry.value));
-      }
+      const args = entries.flatMap((entry) => [
+        entry.key,
+        this.serialize(entry.value),
+      ]);
 
       if (ttlSeconds) {
         // Use pipeline: MSET + EXPIRE for each key

--- a/src/ResilientCacheClient.ts
+++ b/src/ResilientCacheClient.ts
@@ -4,6 +4,7 @@ import type {
   CallOptions,
   ConnectionState,
   ConnectionStatus,
+  GetOrSetOptions,
   ICacheClient,
 } from './types.js';
 import { CacheUnavailableError, CacheTimeoutError } from './errors.js';
@@ -272,8 +273,7 @@ export class ResilientCacheClient implements ICacheClient {
       this.validateTtl(ttlSeconds);
     }
     return this.executeCommand('set', false, options, async () => {
-      const serialized =
-        typeof value === 'string' ? value : JSON.stringify(value);
+      const serialized = this.serialize(value);
       if (ttlSeconds) {
         await this.redis!.set(key, serialized, 'EX', ttlSeconds);
       } else {
@@ -402,13 +402,18 @@ export class ResilientCacheClient implements ICacheClient {
 
   /**
    * Get a value from cache, or set it using a factory function if not found
-   * Implements the cache-aside pattern
+   * Implements the cache-aside pattern with optional staleness validation
+   *
+   * @param key - Cache key
+   * @param factory - Async function to generate the value if cache miss or stale
+   * @param ttlSeconds - Time to live in seconds (optional)
+   * @param options - Options including optional isValid validator
    */
   async getOrSet<T>(
     key: string,
     factory: () => Promise<T>,
     ttlSeconds?: number,
-    _options?: CallOptions,
+    options?: GetOrSetOptions<T>,
   ): Promise<T> {
     this.validateKey(key);
     if (ttlSeconds !== undefined) {
@@ -418,6 +423,16 @@ export class ResilientCacheClient implements ICacheClient {
     // Try to get from cache first (always graceful - cache failure = cache miss)
     const cached = await this.get<T>(key, undefined, { onError: 'graceful' });
     if (cached !== null) {
+      // If validator provided, check if cached value is still valid
+      if (options?.isValid) {
+        const isValid = await options.isValid(cached);
+        if (!isValid) {
+          // Cached value is stale - fetch fresh value
+          const value = await factory();
+          await this.set(key, value, ttlSeconds, { onError: 'graceful' });
+          return value;
+        }
+      }
       return cached;
     }
 
@@ -451,6 +466,136 @@ export class ResilientCacheClient implements ICacheClient {
     return this.executeCommand('ttl', -2, options, async () => {
       const result = await this.redis!.ttl(key);
       return result;
+    });
+  }
+
+  /**
+   * Set a value only if the key does not exist (SETNX)
+   * Useful for distributed locks and deduplication
+   *
+   * @note In graceful mode (default), returns false both when key exists AND when cache is unavailable.
+   * For mutex/lock patterns where you need to distinguish these cases, use { onError: 'throw' }.
+   */
+  async setIfNotExists<T>(
+    key: string,
+    value: T,
+    ttlSeconds?: number,
+    options?: CallOptions,
+  ): Promise<boolean> {
+    this.validateKey(key);
+    if (ttlSeconds !== undefined) {
+      this.validateTtl(ttlSeconds);
+    }
+    return this.executeCommand('setIfNotExists', false, options, async () => {
+      const serialized = this.serialize(value);
+      let result: string | null;
+      if (ttlSeconds) {
+        result = await this.redis!.set(key, serialized, 'EX', ttlSeconds, 'NX');
+      } else {
+        result = await this.redis!.set(key, serialized, 'NX');
+      }
+      return result === 'OK';
+    });
+  }
+
+  /**
+   * Get multiple values from cache in a single round trip (MGET)
+   *
+   * @param keys - Array of cache keys
+   * @param options - Per-call options
+   * @returns Array of values in same order as keys, null for missing keys
+   */
+  async getMany<T>(
+    keys: string[],
+    options?: CallOptions,
+  ): Promise<(T | null)[]> {
+    if (keys.length === 0) {
+      return [];
+    }
+    for (const key of keys) {
+      this.validateKey(key);
+    }
+    const defaultValue = keys.map(() => null) as (T | null)[];
+    return this.executeCommand('getMany', defaultValue, options, async () => {
+      const results = await this.redis!.mget(...keys);
+      return results.map((result) => {
+        if (result === null) {
+          return null;
+        }
+        try {
+          const parsed = JSON.parse(result);
+          return this.sanitizeParsedValue(parsed) as T;
+        } catch {
+          // Return raw string value if not valid JSON
+          return result as unknown as T;
+        }
+      });
+    });
+  }
+
+  /**
+   * Set multiple key-value pairs in cache (MSET)
+   * If ttlSeconds is provided, uses a pipeline to set EXPIRE on each key
+   *
+   * @param entries - Array of { key, value } pairs
+   * @param ttlSeconds - Time to live in seconds (optional, applies to all keys)
+   * @param options - Per-call options
+   * @returns true if all keys were set successfully
+   */
+  async setMany<T>(
+    entries: Array<{ key: string; value: T }>,
+    ttlSeconds?: number,
+    options?: CallOptions,
+  ): Promise<boolean> {
+    if (entries.length === 0) {
+      return true;
+    }
+    for (const entry of entries) {
+      this.validateKey(entry.key);
+    }
+    if (ttlSeconds !== undefined) {
+      this.validateTtl(ttlSeconds);
+    }
+    return this.executeCommand('setMany', false, options, async () => {
+      // Build key-value pairs for MSET
+      const args: string[] = [];
+      for (const entry of entries) {
+        args.push(entry.key, this.serialize(entry.value));
+      }
+
+      if (ttlSeconds) {
+        // Use pipeline: MSET + EXPIRE for each key
+        const pipeline = this.redis!.pipeline();
+        pipeline.mset(...args);
+        for (const entry of entries) {
+          pipeline.expire(entry.key, ttlSeconds);
+        }
+        await pipeline.exec();
+      } else {
+        await this.redis!.mset(...args);
+      }
+      return true;
+    });
+  }
+
+  /**
+   * Update the TTL of an existing key without changing its value (EXPIRE)
+   *
+   * @param key - Cache key
+   * @param ttlSeconds - New time to live in seconds
+   * @param options - Per-call options
+   * @returns true if key exists and TTL was set, false if key doesn't exist
+   */
+  async expire(
+    key: string,
+    ttlSeconds: number,
+    options?: CallOptions,
+  ): Promise<boolean> {
+    this.validateKey(key);
+    this.validateTtl(ttlSeconds);
+    return this.executeCommand('expire', false, options, async () => {
+      const result = await this.redis!.expire(key, ttlSeconds);
+      return result === 1;
     });
   }
 
@@ -634,6 +779,13 @@ export class ResilientCacheClient implements ICacheClient {
     if (!Number.isFinite(value)) {
       throw new TypeError(`${name} must be a finite number`);
     }
+  }
+
+  /**
+   * Serialize a value for storage in Redis
+   */
+  private serialize<T>(value: T): string {
+    return typeof value === 'string' ? value : JSON.stringify(value);
   }
 
   /**

--- a/src/index.ts
+++ b/src/index.ts
@@ -13,6 +13,7 @@ export type {
   CallOptions,
   ConnectionState,
   ConnectionStatus,
+  GetOrSetOptions,
   ICacheClient,
   CacheKeyConfig,
 } from './types.js';


### PR DESCRIPTION
## Summary

- Add `setIfNotExists(key, value, ttl?)` - SETNX for distributed locks/mutex patterns
- Add `getMany<T>(keys)` - MGET for batch fetching in single round trip
- Add `setMany<T>(entries, ttl?)` - MSET for batch setting with optional TTL
- Add `expire(key, ttl)` - Update TTL without changing value
- Enhance `getOrSet` with `isValid` validator for staleness checks
- Extract `serialize()` helper for DRY
- Bump version to 0.3.0

## New API Methods

| Method | Redis Command | Use Case |
|--------|--------------|----------|
| `setIfNotExists(key, value, ttl?)` | `SET ... NX` | Distributed locks, deduplication |
| `getMany<T>(keys)` | `MGET` | Batch fetching (single round trip) |
| `setMany<T>(entries, ttl?)` | `MSET` + pipeline `EXPIRE` | Batch setting |
| `expire(key, ttl)` | `EXPIRE` | Update TTL without changing value |

## Important Notes

**`setIfNotExists` and mutex patterns:**
In graceful mode (default), returns `false` both when key exists AND when cache is unavailable. For mutex/lock patterns where this distinction matters, use `{ onError: 'throw' }`.

## Test plan

- [x] Unit tests for all new methods (18 new tests)
- [x] Tests for throw mode
- [x] Tests for object/complex value serialization
- [x] Tests for edge cases (empty arrays, expired keys)
- [x] Lint passes
- [x] Build passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)